### PR TITLE
Introduce "testee" postfix template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 2020.3.0
 - Initial version
+
+## 2020.3.1
+- Add `testee` postfix template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 2020.3.0
 - Initial version
+
+## 2020.3.1
+- Add `testee` postfix template

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@
 ## Features
 
 - [Postfix template](https://www.jetbrains.com/help/rider/Postfix_Templates.html) `.result` for easier standardization of tests
+- [Postfix template](https://www.jetbrains.com/help/rider/Postfix_Templates.html) `.testee` for easier standardization of tests
 - [Live template](https://www.jetbrains.com/help/rider/Using_Live_Templates.html) `should` to introduce a new assertion for either `result` or the last asserted expression

--- a/ReSharperPlugin.FluentAssertions.sln.DotSettings
+++ b/ReSharperPlugin.FluentAssertions.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=testee/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/dotnet/ReSharperPlugin.FluentAssertions/TesteePostfix.cs
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions/TesteePostfix.cs
@@ -1,0 +1,43 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.CSharp.PostfixTemplates;
+using JetBrains.ReSharper.Feature.Services.CSharp.PostfixTemplates.Behaviors;
+using JetBrains.ReSharper.Feature.Services.CSharp.PostfixTemplates.Contexts;
+using JetBrains.ReSharper.Feature.Services.PostfixTemplates;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+
+namespace ReSharperPlugin.FluentAssertions
+{
+    [PostfixTemplate("testee", "Introduce testee variable", "var testee = expr;")]
+    public class TesteePostfixTemplate : CSharpPostfixTemplate
+    {
+        public override PostfixTemplateInfo TryCreateInfo(CSharpPostfixTemplateContext context)
+        {
+            var withValuesContexts = CSharpPostfixUtils.FindExpressionWithValuesContexts(context);
+            return withValuesContexts.Length == 0
+                ? null
+                : new PostfixTemplateInfo("testee", withValuesContexts, availableInPreciseMode: true);
+        }
+
+        public override PostfixTemplateBehavior CreateBehavior(PostfixTemplateInfo info)
+        {
+            return new TesteePostfixBehavior(info);
+        }
+
+        private sealed class TesteePostfixBehavior : CSharpStatementPostfixTemplateBehavior<ICSharpStatement>
+        {
+            public TesteePostfixBehavior([NotNull] PostfixTemplateInfo info)
+                : base(info)
+            {
+            }
+
+            protected override string ExpressionSelectTitle => "Select expression to introduce as variable";
+
+            protected override ICSharpStatement CreateStatement(CSharpElementFactory factory,
+                ICSharpExpression expression)
+            {
+                return factory.CreateStatement("var testee = $0;", expression);
+            }
+        }
+    }
+}

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
       BDD-style unit tests.</p>
 <ul>
   <li><a href="https://www.jetbrains.com/help/rider/Postfix_Templates.html">Postfix template</a> <code>.result</c> for easier standardization of tests</li>
+  <li><a href="https://www.jetbrains.com/help/rider/Postfix_Templates.html">Postfix template</a> <code>.testee</c> for easier standardization of tests</li>
   <li><a href="https://www.jetbrains.com/help/rider/Using_Live_Templates.html">Live template</a> <code>should</code> to introduce a new assertion for either <code>result</code> or the last asserted expression</li>
 </ul>
 ]]>


### PR DESCRIPTION
This PR includes another postfix template called `testee`. Like `.result`, it aims to standardize tests.