### PR TITLE
Fix bug for complex types

### DIFF
--- a/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullClassBug.cs
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullClassBug.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+
+public class ExampleTests
+{
+    [Test]
+    public void Test()
+    {
+        // arrange
+
+        // act
+        TempClass result = null;
+        
+        // assert
+        {caret}Assert.IsNotNull(result);
+    }
+}
+
+public class TempClass
+{
+    public string Type { get; set; }
+}

--- a/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullClassBug.cs.gold
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullClassBug.cs.gold
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+public class ExampleTests
+{
+    [Test]
+    public void Test()
+    {
+        // arrange
+
+        // act
+        TempClass result = null;
+        
+        // assert
+        {caret}result.Should().NotBeNull();
+    }
+}
+
+public class TempClass
+{
+    public string Type { get; set; }
+}

--- a/src/dotnet/ReSharperPlugin.FluentAssertions/Psi/FluentAssertionsPredefinedType.cs
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions/Psi/FluentAssertionsPredefinedType.cs
@@ -50,8 +50,11 @@ namespace ReSharperPlugin.FluentAssertions.Psi
                 .GetTypeElement().Methods
                 .Where(x => x.ShortName == "Should");
 
-            return methods
-                .FirstOrDefault(x => x.Parameters.Any(t => t.Type.Equals(type)));
+            var objectType =
+                TypeFactory.CreateTypeByCLRName(PredefinedType.OBJECT_FQN, NullableAnnotation.Unknown, Module);
+
+            return methods.FirstOrDefault(
+                x => x.Parameters.Any(t => t.Type.Equals(type.IsSimplePredefined() ? type : objectType)));
         }
 
         [CanBeNull]


### PR DESCRIPTION
When validating a complex type that it should not be Null, there was no replacement with Should(). NotBeNull ()