### PR TITLE
Fix assertion for nullable types

### DIFF
--- a/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullNullableTypeBug.cs
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullNullableTypeBug.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+
+public class ExampleTests
+{
+    [Test]
+    public void Test()
+    {
+        // arrange
+
+        // act
+        TempClass result = new();
+        
+        // assert
+        {caret}Assert.IsNotNull(result.Type);
+    }
+}
+
+public class TempClass
+{
+    public int? Type { get; set; }
+}

--- a/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullNullableTypeBug.cs.gold
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/test/data/NUnitAssertMigrationQuickFixTests/PositiveCaseIsNotNullNullableTypeBug.cs.gold
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+public class ExampleTests
+{
+    [Test]
+    public void Test()
+    {
+        // arrange
+
+        // act
+        TempClass result = new();
+        
+        // assert
+        {caret}result.Type.Should().NotBeNull();
+    }
+}
+
+public class TempClass
+{
+    public int? Type { get; set; }
+}

--- a/src/dotnet/ReSharperPlugin.FluentAssertions/Psi/FluentAssertionsPredefinedType.cs
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions/Psi/FluentAssertionsPredefinedType.cs
@@ -54,7 +54,7 @@ namespace ReSharperPlugin.FluentAssertions.Psi
                 TypeFactory.CreateTypeByCLRName(PredefinedType.OBJECT_FQN, NullableAnnotation.Unknown, Module);
 
             return methods.FirstOrDefault(
-                x => x.Parameters.Any(t => t.Type.Equals(type.IsSimplePredefined() ? type : objectType)));
+                x => x.Parameters.Any(t => t.Type.Equals(type.IsSimplePredefined() || type.IsNullable() ? type : objectType)));
         }
 
         [CanBeNull]


### PR DESCRIPTION
Now for cases where class contains nullable type replace code:
``` csharp
 [Test]
    public void Test()
    {
        // arrange

        // act
        TempClass result = new();
        
        // assert
        {caret}Assert.IsNotNull(result.Type);
    }
```
on code
``` csharp
 [Test]
    public void Test()
    {
        // arrange

        // act
        TempClass result = new();
        
        // assert
        {caret}AssertionExtensions.Should((object)result.Type).NotBeNull();
    }
```
But shoul replace on 
``` csharp
 [Test]
    public void Test()
    {
        // arrange

        // act
        TempClass result = new();
        
        // assert
        {caret}result.Type.Should().NotBeNull();
    }
```