### PR TITLE
Use GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  CI:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install and setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0'
+    - name: Run .NET tests
+      run: dotnet test
+    - name: Import the Corretto public key
+      run: wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add - 
+    - name: Add the repository to the system list
+      run: sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+    - name: Install Corretto 11
+      run: sudo apt-get update; sudo apt-get install -y java-11-amazon-corretto-jdk
+    - name: Mark gradlew as executable
+      run: chmod 777 gradlew    
+    - name: Build Rider and ReSharper plugin
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: buildPlugin    

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '*' # Push events to matching everything, e. g. "v1" or "2021.2.2.1"
+
+jobs:
+  Release:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Extract Git tag
+      uses: olegtarasov/get-tag@v2.1
+      id: tagName
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install and setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0'
+    - name: Run .NET tests
+      run: dotnet test
+    - name: Import the Corretto public key
+      run: wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add - 
+    - name: Add the repository to the system list
+      run: sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+    - name: Install Corretto 11
+      run: sudo apt-get update; sudo apt-get install -y java-11-amazon-corretto-jdk
+    - name: Mark gradlew as executable
+      run: chmod 777 gradlew    
+    - name: Build Rider and ReSharper plugin
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: publishPlugin -PPublishToken=${{ secrets.JETBRAINSPUBLISHTOKEN }}    
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: /output/ReSharperPlugin.FluentAssertions.*.nupkg
+        tag_name: ${{ steps.tagName.outputs.tag }}

--- a/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/ReSharperPlugin.FluentAssertions.Tests.csproj
+++ b/src/dotnet/ReSharperPlugin.FluentAssertions.Tests/ReSharperPlugin.FluentAssertions.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="$(SdkVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq.AutoMock" Version="3.3.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The steps itself (`dotnet test`, `gradle buildPlugin`, etc.) do work properly. But I could not yet test the complete GitHub Action because [`act`](https://github.com/nektos/act) does not support running on Windows, only on Ubuntu. Due to the dependency to .NET Framework 4.7.2, the GitHub Action must run on Windows.  
Unfortunately, the new GitHub Actions are not triggered in my personal repo - probably because it's a fork. Maybe we have to merge them first and cross fingers that they work. If not, of course I will take the responsibility for them and provide bugfixes asap.