### PR TITLE
Use GitHub Action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  CI:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install and setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0'
+    - name: Run .NET tests
+      run: dotnet test
+    - name: Build Rider and ReSharper plugin
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: buildPlugin

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '*' # Push events to matching everything, e. g. "v1" or "2021.2.2.1"
+
+jobs:
+  Release:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install and setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0'
+    - name: Run .NET tests
+      run: dotnet test
+    - name: Build and publish Rider and ReSharper plugin
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: publishPlugin -PPublishToken=${{ secrets.JETBRAINSPUBLISHTOKEN }}

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SdkVersion>2022.1.0-eap07</SdkVersion>
+    <SdkVersion>2022.1.0</SdkVersion>
 
     <Title>FluentAssertions</Title>
     <Description>Support plugin for FluentAssertions. A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or


### PR DESCRIPTION
This PR introduces two GitHub Actions:
- `CI.yml` → triggered on every build, runs the .NET tests and builds the Rider and R# plugin
- `Release.yml` → triggered on tagged builds, runs the .NET tests, builds and publishes the Rider and R# plugin. For this, the GitHub repo secret `JETBRAINSPUBLISHTOKEN` has to be set

Maybe its worth considering to configure the CI build as an automatic merge check to ensure that the tests are getting executed.